### PR TITLE
VM 프레임 관리 : vm_claim_page 함수 추가

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -150,7 +150,6 @@ void vm_dealloc_page(struct page *page) {
 /* Claim the page that allocate on VA. */
 bool vm_claim_page(void *va UNUSED) {
     struct page *page = NULL;
-    /* TODO: Fill this function */
 
     page = spt_find_page(&thread_current()->spt, va);
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -152,7 +152,13 @@ bool vm_claim_page(void *va UNUSED) {
     struct page *page = NULL;
     /* TODO: Fill this function */
 
-    return vm_do_claim_page(page);
+    page = spt_find_page(&thread_current()->spt, va);
+
+    if (page != NULL) {
+        return vm_do_claim_page(page);
+    }
+
+    return false;
 }
 
 /* Claim the PAGE and set up the mmu. */


### PR DESCRIPTION
vm_claim_page는 va를 할당하기 위해 주어진 페이지를 할당합니다. 
페이지를 먼저 할당하고 이후에 vm_do_claim_page를 호출합니다. 

먼저, spt_find_page로 페이지가 이미 존재하는지 찾아봅니다. 반환값이 NULL이 아닐때는 vm_do_claim_page를 호출하고, 반환값이 NULL이라면 false를 리턴합니다. 