### PR TITLE
feat: vm_get_frame() 함수 구현됨 (테스트 안함)

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -45,6 +45,9 @@ struct page {
 struct frame {
     void *kva;
     struct page *page;
+
+    // frame_table Push 및 페이지 교체 알고리즘을 적용하기 위해 추가함
+    struct list_elem elem;
 };
 
 /* The function table for page operations.

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -2,8 +2,12 @@
 
 #include "vm/vm.h"
 
+#include "list.h"
 #include "threads/malloc.h"
 #include "vm/inspect.h"
+
+struct list frame_table;
+struct lock frame_table_lock;
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -16,6 +20,7 @@ void vm_init(void) {
     register_inspect_intr();
     /* DO NOT MODIFY UPPER LINES. */
     /* TODO: Your code goes here. */
+    list_init(&frame_table);
 }
 
 /* Get the type of the page. This function is useful if you want to know the
@@ -106,7 +111,7 @@ static struct frame *vm_get_victim(void) {
 static struct frame *vm_evict_frame(void) {
     struct frame *victim UNUSED = vm_get_victim();
     /* TODO: swap out the victim and return the evicted frame. */
-
+    swap_out(victim->page);
     return NULL;
 }
 
@@ -115,11 +120,22 @@ static struct frame *vm_evict_frame(void) {
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
 static struct frame *vm_get_frame(void) {
-    struct frame *frame = NULL;
-    /* TODO: Fill this function. */
+    struct frame *frame = (struct frame *)malloc(sizeof(struct frame));
 
     ASSERT(frame != NULL);
     ASSERT(frame->page == NULL);
+
+    frame->kva = palloc_get_page(PAL_USER);
+    if (frame->kva == NULL) {
+        frame = vm_evict_frame();
+        frame->page = NULL;
+        return frame;
+    }
+
+    lock_acquire(&frame_table_lock);
+    list_push_back(&frame_table, &frame->elem);
+    lock_release(&frame_table_lock);
+
     return frame;
 }
 


### PR DESCRIPTION
사용자 프로세스의 가상 페이지를 매핑할 수 있도록 유저 풀에서 메모리를 확보해서 반화하는 함수다.

만약 메모리가 부족하면 페이지 교체 알고리즘을 통해 프레임을 강제로 확보한다.