### PR TITLE
vm_get_victim() 함수 작성 완료

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -125,11 +125,10 @@ struct thread {
     struct semaphore fork_sema;  // fork 동기화용
     struct thread *parent;       // 부모 스레드 포인터
 
-
-#ifdef USERPROG
-    /* Owned by userprog/process.c. */
+    // #ifdef USERPROG
+    /* Owned by userprog/process.c and vm.c. */
     uint64_t *pml4; /* Page map level 4 */
-#endif
+    // #endif
 #ifdef VM
     /* Table for whole virtual memory owned by thread. */
     struct supplemental_page_table spt;

--- a/pintos/include/vm/uninit.h
+++ b/pintos/include/vm/uninit.h
@@ -22,4 +22,6 @@ struct uninit_page {
 
 void uninit_new(struct page *page, void *va, vm_initializer *init, enum vm_type type, void *aux,
                 bool (*initializer)(struct page *, enum vm_type, void *kva));
+
+bool fragment_uninit_initialize(struct page *page, void *kva);
 #endif

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -27,8 +27,12 @@ struct page {
     void *va;            /* Address in terms of user space */
     struct frame *frame; /* Back reference for frame */
 
-    /* Your implementation */
+    // Supplement table에서 사용함
     struct hash_elem hash_elem;
+
+    // 역참조용
+    struct thread *owner;
+
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */
     union {

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -39,6 +39,10 @@ void uninit_new(struct page *page, void *va, vm_initializer *init, enum vm_type 
                           }};
 }
 
+bool fragment_uninit_initialize(struct page *page, void *kva) {
+    return uninit_initialize(page, kva);
+}
+
 /* Initalize the page on first fault */
 static bool uninit_initialize(struct page *page, void *kva) {
     struct uninit_page *uninit = &page->uninit;


### PR DESCRIPTION
1. 테스트 전인 점 유의해주세요.
2. thread.c > struct thread의 #ifdef USERPROG가 주석처리 되었습니다. (pml4를 vm 환경에서도 체크하기 위함입니다.)
3. advance_clock_hand() 함수가 추가적으로 작성되었습니다. (시계 방향으로 프레임을 조회하기 위한 함수입니다.)
4. frame_table, frame_table_lock가 static으로 변경되었습니다.
5. spt_insert_page() 내에 역참조용 객체를 초기화합니다. (2번과 연관되어 있습니다.)