### PR TITLE
Lazy Loading : vm_alloc_page_with_initializer 함수 수정

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -65,6 +65,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
         // file_backed_initializer -> 2
         struct page *page = (struct page *)malloc(sizeof(struct page));
 
+        /* 포인터 타입 함수 */
         typedef bool (*initializerFunc)(struct page *, enum vm_type, void *);
         initializerFunc initializer = NULL;
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -63,18 +63,17 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
         // anon_initializer -> 익명 페이지 1
         // uninit_initialize -> 0
         // file_backed_initializer -> 2
-        struct page *p = (struct page *)malloc(sizeof(struct page));
-        p->va = upage;
+        struct page *page = (struct page *)malloc(sizeof(struct page));
 
-        switch (type) {
-            case VM_UNINIT:
-                uninit_new(p, p->va, init, type, aux, fragment_uninit_initialize);
-                break;
+        typedef bool (*initializerFunc)(struct page *, enum vm_type, void *);
+        initializerFunc initializer = NULL;
+
+        switch (VM_TYPE(type)) {
             case VM_ANON:
-                uninit_new(p, p->va, init, type, aux, anon_initializer);
+                initializer = anon_initializer;
                 break;
             case VM_FILE:
-                uninit_new(p, p->va, init, type, aux, file_backed_initializer);
+                initializer = file_backed_initializer;
                 break;
             case VM_PAGE_CACHE:
                 PANIC("쌈@뽕하게 Proj4는 무시");
@@ -84,8 +83,10 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
                 break;
         }
 
+        uninit_new(page, upage, init, type, aux, initializer);
+
         /* TODO: Insert the page into the spt. */
-        return spt_insert_page(spt, p);
+        return spt_insert_page(spt, page);
     }
 err:
     return false;


### PR DESCRIPTION
코어시간에 이거 어떻게 못하나??? 했던 부분을 찾아보니 이런식으로도 가능 하더랍니다....

변경사항 : 
1. VM_UNINIT는 vm_alloc_page_with_initializer 함수에서 필요 없다고 하여 삭제했습니다
2. initializerFunc 함수 포인터 사용 -> 중복 줄이기




