### PR TITLE
Fix: bad-ptr 너 나가!!!!!!!!

### DIFF
--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -141,6 +141,9 @@ static void page_fault(struct intr_frame *f) {
     /* For project 3 and later. */
     if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
         return;
+    else {
+        exit(-1);
+    }
 #endif
 
     /* Count page faults. */


### PR DESCRIPTION
syscall, 커널에서 발생한 폴트를 죽기 전에 exit(-1)을 해줍니다. 